### PR TITLE
Untitled

### DIFF
--- a/lib/stalker.rb
+++ b/lib/stalker.rb
@@ -26,6 +26,11 @@ module Stalker
 		@@handlers[j] = block
 	end
 
+	def before(&block)
+		@@before_handlers ||= []
+		@@before_handlers << block
+	end
+
 	def error(&blk)
 		@@error_handler = blk
 	end
@@ -70,6 +75,11 @@ module Stalker
 
 		begin
 			Timeout::timeout(job.ttr - 1) do
+				if defined? @@before_handlers and @@before_handlers.respond_to? :each
+					@@before_handlers.each do |block|
+						block.call(name)
+					end
+				end
 				handler.call(args)
 			end
 		rescue Timeout::Error
@@ -161,6 +171,7 @@ module Stalker
 
 	def clear!
 		@@handlers = nil
+		@@before_handlers = nil
 		@@error_handler = nil
 	end
 end

--- a/test/stalker_test.rb
+++ b/test/stalker_test.rb
@@ -48,4 +48,42 @@ class StalkerTest < Test::Unit::TestCase
 		Stalker.work_one_job
 		assert_equal Stalker::JobTimeout, $handled
 	end
+
+	test "before filter gets run first" do
+		Stalker.before { |name| $flag = "i_was_here" }
+		Stalker.job('my.job') { |args| $handled = ($flag == 'i_was_here') }
+		Stalker.enqueue('my.job')
+		Stalker.prep
+		Stalker.work_one_job
+		assert_equal true, $handled
+	end
+
+	test "before filter passes the name of the job" do
+		Stalker.before { |name| $jobname = name }
+		Stalker.job('my.job') { true }
+		Stalker.enqueue('my.job')
+		Stalker.prep
+		Stalker.work_one_job
+		assert_equal 'my.job', $jobname
+	end
+
+	test "before filter can pass an instance var" do
+		Stalker.before { |name| @foo = "hello" }
+		Stalker.job('my.job') { |args| $handled = (@foo == "hello") }
+		Stalker.enqueue('my.job')
+		Stalker.prep
+		Stalker.work_one_job
+		assert_equal true, $handled
+	end
+
+	test "before filter invokes error handler when defined" do
+		Stalker.error { |e| $handled = true }
+		Stalker.before { |name| fail }
+		Stalker.job('my.job') {	}
+		Stalker.enqueue('my.job')
+		Stalker.prep
+		Stalker.work_one_job
+		assert_equal true, $handled
+	end
+
 end


### PR DESCRIPTION
Implemented an optional before block that gets run before each job.

I did an explicit defined? and respond_to? check on @@before_handlers since it seemed more obvious than the other methods. Also learned that @foo is nil? if undefined, whereas @@foo throws an exception. Thanks for pointing that out :)
