### PR TITLE
Support for multiple beanstalk servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Tidbits
 
 * Jobs are serialized as JSON, so you should stick to strings, integers, arrays, and hashes as arguments to jobs.  e.g. don't pass full Ruby objects - use something like an ActiveRecord/MongoMapper/CouchRest id instead.
 * Because there are no class definitions associated with jobs, you can queue jobs from anywhere without needing to include your full app's environment.
-* If you need to change the location of your Beanstalk from the default (localhost:11300), set BEANSTALK_URL in your environment, e.g. export BEANSTALK_URL=beanstalk://example.com:11300/
+* If you need to change the location of your Beanstalk from the default (localhost:11300), set BEANSTALK_URL in your environment, e.g. export BEANSTALK_URL=beanstalk://example.com:11300/. You can specify multiple beanstalk servers, separated by whitespace or comma, e.g. export BEANSTALK_URL="beanstalk://b1.example.com:11300/, beanstalk://b2.example.com:11300/"
 * The stalk binary is just for convenience, you can also run a worker with a straight Ruby command:
     $ ruby -r jobs -e Stalker.work
 

--- a/lib/stalker.rb
+++ b/lib/stalker.rb
@@ -134,7 +134,7 @@ module Stalker
 	end
 
 	def beanstalk
-		@@beanstalk ||= Beanstalk::Pool.new([ beanstalk_host_and_port ])
+		@@beanstalk ||= Beanstalk::Pool.new(beanstalk_addresses)
 	end
 
 	def beanstalk_url
@@ -144,10 +144,15 @@ module Stalker
 
 	class BadURL < RuntimeError; end
 
-	def beanstalk_host_and_port
-		uri = URI.parse(beanstalk_url)
-		raise(BadURL, beanstalk_url) if uri.scheme != 'beanstalk'
-		return "#{uri.host}:#{uri.port || 11300}"
+  def beanstalk_addresses
+    uris = beanstalk_url.split(/[\s,]+/)
+    uris.map {|uri| beanstalk_host_and_port(uri)}
+  end
+
+	def beanstalk_host_and_port(uri_string)
+		uri = URI.parse(uri_string)
+		raise(BadURL, uri_string) if uri.scheme != 'beanstalk'
+		"#{uri.host}:#{uri.port || 11300}"
 	end
 
 	def exception_message(e)


### PR DESCRIPTION
BEANSTALK_URL may specify multiple beanstalk URI's, separated by whitespace or comma. All are added to beanstalk-client's Beanstalk::Pool.
