### PR TITLE
Add job name and args to error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Error Handling
 
 If you include an `error` block in your jobs definition, that block will be invoked when a worker encounters an error. You might use this to report errors to an external monitoring service:
 
-    error do |e|
+    error do |job_name, args, e|
       Exceptional.handle(e)
     end
 

--- a/lib/stalker.rb
+++ b/lib/stalker.rb
@@ -96,7 +96,7 @@ module Stalker
 		log_error exception_message(e)
 		job.bury rescue nil
 		log_job_end(name, 'failed')
-		error_handler.call(e) if error_handler
+		error_handler.call(name, args, e) if error_handler
 	end
 
 	def failed_connection(e)


### PR DESCRIPTION
Hello,

We would like to use stalker in our project, but one of the things we require is an ability to restart jobs. In order to do that, we plan to save job name and it's arguments along with the exception in the database. The error handler would be a perfect place to do that, however the job name and arguments are not easily available there. This commit adds job name and it's arguments to the error handler.

Best regards,
Adam Pohorecki
