### PR TITLE
Add job name and args to error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Error Handling
 
 If you include an `error` block in your jobs definition, that block will be invoked when a worker encounters an error. You might use this to report errors to an external monitoring service:
 
-    error do |job_name, args, e|
+    error do |e, job_name, args|
       Exceptional.handle(e)
     end
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Error Handling
 
 If you include an `error` block in your jobs definition, that block will be invoked when a worker encounters an error. You might use this to report errors to an external monitoring service:
 
-    error do |e|
+    error do |job_name, args, e|
       Exceptional.handle(e)
     end
 

--- a/lib/stalker.rb
+++ b/lib/stalker.rb
@@ -96,7 +96,13 @@ module Stalker
 		log_error exception_message(e)
 		job.bury rescue nil
 		log_job_end(name, 'failed')
-		error_handler.call(name, args, e) if error_handler
+    if error_handler
+      if error_handler.arity == 1
+        error_handler.call(e)
+      else
+        error_handler.call(e, name, args)
+      end
+    end
 	end
 
 	def failed_connection(e)

--- a/lib/stalker.rb
+++ b/lib/stalker.rb
@@ -96,7 +96,7 @@ module Stalker
 		log_error exception_message(e)
 		job.bury rescue nil
 		log_job_end(name, 'failed')
-		error_handler.call(e) if error_handler
+		error_handler.call(name, args, e) if error_handler
 	end
 
 	def failed_connection(e)


### PR DESCRIPTION
Hi,

Like you asked, I changed the order of arguments to the error handler. This was not enough to not break the current error handlers (the argument would contain an array instead of just the exception), so now the error handler arity is checked to call it with the right arguments.

Best regards,
Adam
